### PR TITLE
Adds page titles for home and configuration in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 docs_dir: docs/book
 site_dir: docs/html
 pages:
-    - index.md
+    - Home: index.md
     - Introduction: v1/intro.md
-    - v1/config.md
+    - Configuration: v1/config.md
     - "Manual Usage": v1/manual.md
 site_name: zend-expressive-session-cache
 site_description: 'PSR-6 session persistence adapter for zend-expressive-session.'


### PR DESCRIPTION
The current problems:

![docs zendframework com_zend-expressive-session-cache_ screenshots fur website](https://user-images.githubusercontent.com/103362/46714645-e375b600-cc5c-11e8-8bf7-7e4dcd9bf8ac.png)
