### PR TITLE
Allow creating persistent session cookies

### DIFF
--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -8,6 +8,8 @@ This package allows configuring the following items:
 - The cache limiter (which controls how resources using sessions are cached by the browser).
 - When the session expires.
 - When the resource using a session was last modified.
+- Whether or not to create a _persistent_ session cookie (i.e., one that will
+  not expire when the browser is closed).
 
 This document details how to configure each of these items.
 
@@ -111,6 +113,13 @@ return [
         // - the index.php file of the current working directory
         // - the current working directory
         'last_modified' => null,
+
+        // A boolean value indicating whether or not the session cookie
+        // should persist. By default, this is disabled (false); passing
+        // a boolean true value will enable the feature. When enabled, the
+        // cookie will be generated with a Max-Age directive equal to the
+        // cache_expire value as noted above.
+        'persistent' => false,
     ],
 ];
 ```

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,4 +1,4 @@
-# zend-expressive-session-cache
+# Introduction
 
 This component provides a [PSR-6](https://www.php-fig.org/psr/psr-6/) session
 persistence adapter for use with [zend-expressive-session](https://docs.zendframework.com/zend-expressive-session/).

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -19,6 +19,9 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
  *     modified. If not provided, this will look for each of
  *     public/index.php, index.php, and finally the current working
  *     directory, using the filemtime() of the first found.
+ * @param bool $persistent Whether or not to create a persistent cookie. If
+ *     provided, this sets the Max-Age for the cookie to the value of
+ *     $cacheExpire.
  */
 public function __construct(
     \Psr\Cache\CacheItemPoolInterface $cache,
@@ -26,7 +29,8 @@ public function __construct(
     string $cookiePath = '/',
     string $cacheLimiter = 'nocache',
     int $cacheExpire = 10800,
-    ?int $lastModified = null
+    ?int $lastModified = null,
+    bool $persistent = false
 ) {
 ```
 

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -30,6 +30,7 @@ class CacheSessionPersistenceFactory
         $cacheLimiter = $config['cache_limiter'] ?? 'nocache';
         $cacheExpire  = $config['cache_expire'] ?? 10800;
         $lastModified = $config['last_modified'] ?? null;
+        $persistent   = $config['persistent'] ?? false;
 
         return new CacheSessionPersistence(
             $container->get($cacheService),
@@ -37,7 +38,8 @@ class CacheSessionPersistenceFactory
             $cookiePath,
             $cacheLimiter,
             $cacheExpire,
-            $lastModified
+            $lastModified,
+            $persistent
         );
     }
 }

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -58,6 +58,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertAttributeSame('nocache', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
+        $this->assertAttributeSame(false, 'persistent', $persistence);
     }
 
     public function testFactoryAllowsConfiguringAllConstructorArguments()
@@ -74,6 +75,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
                 'cache_limiter' => 'public',
                 'cache_expire'  => 300,
                 'last_modified' => $lastModified,
+                'persistent'    => true,
             ],
         ]);
         $this->container->has(CacheItemPoolInterface::class)->willReturn(true);
@@ -92,6 +94,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
             'lastModified',
             $persistence
         );
+        $this->assertAttributeSame(true, 'persistent', $persistence);
     }
 
     public function testFactoryAllowsConfiguringCacheAdapterServiceName()


### PR DESCRIPTION
By default, cookies created to indicate a session cookie expire when the browser closes or after a period of inactivity.

Sometimes, however, it's useful to have _persistent_ session cookies, so that the user does not need to log in repeatedly. PHP allows this via the `session.cookie_lifetime` INI setting.

This patch provides the ability to mark a session cookie as persistent.  When marked, the `cache_expire` value is used to set the `Max-Age` directive of the cookie.

To configure it, use the `zend-expressive-session-cache.persistent` configuration setting, passing a boolean `true` value to enable it. By default, the value is `false`.