### PR TITLE
Use Expires instead of Max-Age when setting persistent cookie

### DIFF
--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -117,8 +117,8 @@ return [
         // A boolean value indicating whether or not the session cookie
         // should persist. By default, this is disabled (false); passing
         // a boolean true value will enable the feature. When enabled, the
-        // cookie will be generated with a Max-Age directive equal to the
-        // cache_expire value as noted above.
+        // cookie will be generated with an Expires directive equal to the
+        // the current time plus the cache_expire value as noted above.
         'persistent' => false,
     ],
 ];

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -20,8 +20,8 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
  *     public/index.php, index.php, and finally the current working
  *     directory, using the filemtime() of the first found.
  * @param bool $persistent Whether or not to create a persistent cookie. If
- *     provided, this sets the Max-Age for the cookie to the value of
- *     $cacheExpire.
+ *     provided, this sets the Expires directive for the cookie based on
+ *     the value of $cacheExpire.
  */
 public function __construct(
     \Psr\Cache\CacheItemPoolInterface $cache,

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Session\Cache;
 
+use DateInterval;
+use DateTimeImmutable;
 use Dflydev\FigCookies\FigRequestCookies;
 use Dflydev\FigCookies\FigResponseCookies;
 use Dflydev\FigCookies\SetCookie;
@@ -95,8 +97,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      *     public/index.php, index.php, and finally the current working
      *     directory, using the filemtime() of the first found.
      * @param bool $persistent Whether or not to create a persistent cookie. If
-     *     provided, this sets the Max-Age for the cookie to the value of
-     *     $cacheExpire.
+     *     provided, this sets the Expires directive for the cookie based on
+     *     the value of $cacheExpire.
      */
     public function __construct(
         CacheItemPoolInterface $cache,
@@ -162,7 +164,9 @@ class CacheSessionPersistence implements SessionPersistenceInterface
             ->withPath($this->cookiePath);
 
         if ($this->persistent) {
-            $sessionCookie = $sessionCookie->withMaxAge($this->cacheExpire);
+            $sessionCookie = $sessionCookie->withExpires(
+                (new DateTimeImmutable())->add(new DateInterval(sprintf('PT%dS', $this->cacheExpire)))
+            );
         }
 
         $response = FigResponseCookies::set($response, $sessionCookie);


### PR DESCRIPTION
The behavior of PHP's `setcookie()` and Swoole's `Swoole\Http\Response::cookie()` are such that they can only set the `Expires` value, and not the `Max-Age` value. While Swoole has has a `rawcookie()` method, it still parses the cookie and sets only values it understands, which do not include `Max-Age`. As such, the most resilient way to handle this is to use the `Expires` directive instead, which will lead to the same behavior.