### PR TITLE
Support Session::getSessionLifetime() to enable runtime session persistence TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,14 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.2.0 - TBD
+## 1.2.0 - 2018-10-31
 
 ### Added
 
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
-## 1.1.2 - TBD
-
-### Added
-
-- Nothing.
+- [#5](https://github.com/zendframework/zend-expressive-session-cache/pull/5) adds support for the new `SessionCookiePersistenceInterface` added
+  in zend-expressive-session 1.2.0.  Specifically, `CacheSessionPersistence` now
+  queries the session instance `getSessionLifetime()` method to determine
+  whether or not to send an `Expires` directive with the session cookie.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "dflydev/fig-cookies": "^1.0.2 || ^2.0",
         "psr/cache": "^1.0",
         "psr/container": "^1.0",
-        "zendframework/zend-expressive-session": "^1.1"
+        "zendframework/zend-expressive-session": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b2daa1ba323b1f38fdbfbc6b70b9899",
+    "content-hash": "3b66ac88e5a6ebf632c9958b287b05ca",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -313,16 +313,16 @@
         },
         {
             "name": "zendframework/zend-expressive-session",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-session.git",
-                "reference": "1bcb8e7869b47e30f1ba692f15e52481d1d550db"
+                "reference": "de67a644d34848451e137919b7018161f7dced13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/1bcb8e7869b47e30f1ba692f15e52481d1d550db",
-                "reference": "1bcb8e7869b47e30f1ba692f15e52481d1d550db",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/de67a644d34848451e137919b7018161f7dced13",
+                "reference": "de67a644d34848451e137919b7018161f7dced13",
                 "shasum": ""
             },
             "require": {
@@ -345,8 +345,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev",
-                    "dev-develop": "1.2.x-dev"
+                    "dev-master": "1.2.x-dev",
+                    "dev-develop": "1.3.x-dev"
                 },
                 "zf": {
                     "config-provider": "Zend\\Expressive\\Session\\ConfigProvider"
@@ -371,7 +371,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-09-12T15:16:19+00:00"
+            "time": "2018-10-30T21:08:51+00:00"
         }
     ],
     "packages-dev": [

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -119,6 +119,13 @@ return [
         // a boolean true value will enable the feature. When enabled, the
         // cookie will be generated with an Expires directive equal to the
         // the current time plus the cache_expire value as noted above.
+        //
+        // As of 1.1.0, developers may define the session TTL by calling the
+        // session instance's `persistSessionFor(int $duration)` method. When
+        // this is present, the engine will use that value even if the below
+        // flag is toggled off. When the flag is enabled, the session TTL will
+        // be honored if it is greater than zero; otherwise, the cache_expire
+        // value will be used, as this defines the global default behavior.
         'persistent' => false,
     ],
 ];

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -120,12 +120,10 @@ return [
         // cookie will be generated with an Expires directive equal to the
         // the current time plus the cache_expire value as noted above.
         //
-        // As of 1.1.0, developers may define the session TTL by calling the
+        // As of 1.2.0, developers may define the session TTL by calling the
         // session instance's `persistSessionFor(int $duration)` method. When
-        // this is present, the engine will use that value even if the below
-        // flag is toggled off. When the flag is enabled, the session TTL will
-        // be honored if it is greater than zero; otherwise, the cache_expire
-        // value will be used, as this defines the global default behavior.
+        // that method has been called, the engine will use that value even if
+        // the below flag is toggled off.
         'persistent' => false,
     ],
 ];

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -23,9 +23,8 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
  *     provided, this sets the Expires directive for the cookie based on
  *     the value of $cacheExpire. Developers can also set the expiry at
  *     runtime via the Session instance, using its persistSessionFor()
- *     method; that value will be used in all cases unless it is zero
- *     and $persistent is toggled to true, in which case the value of
- *     $cacheExpire will be used.
+ *     method; that value will be honored even if global persistence
+ *     is toggled true here.
  */
 public function __construct(
     \Psr\Cache\CacheItemPoolInterface $cache,

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -21,7 +21,11 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
  *     directory, using the filemtime() of the first found.
  * @param bool $persistent Whether or not to create a persistent cookie. If
  *     provided, this sets the Expires directive for the cookie based on
- *     the value of $cacheExpire.
+ *     the value of $cacheExpire. Developers can also set the expiry at
+ *     runtime via the Session instance, using its persistSessionFor()
+ *     method; that value will be used in all cases unless it is zero
+ *     and $persistent is toggled to true, in which case the value of
+ *     $cacheExpire will be used.
  */
 public function __construct(
     \Psr\Cache\CacheItemPoolInterface $cache,

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -325,9 +325,10 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     private function getPersistenceDuration(SessionInterface $session) : int
     {
         $duration = $this->persistent ? $this->cacheExpire : 0;
-        if ($session instanceof SessionInterface) {
-            $ttl = $session->getSessionLifetime();
-            $duration = $ttl ? $ttl : $duration;
+        if ($session instanceof SessionCookiePersistenceInterface
+            && $session->has(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY)
+        ) {
+            $duration = $session->getSessionLifetime();
         }
         return $duration < 0 ? 0 : $duration;
     }

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -99,7 +99,10 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      *     directory, using the filemtime() of the first found.
      * @param bool $persistent Whether or not to create a persistent cookie. If
      *     provided, this sets the Expires directive for the cookie based on
-     *     the value of $cacheExpire.
+     *     the value of $cacheExpire. Developers can also set the expiry at
+     *     runtime via the Session instance, using its persistSessionFor()
+     *     method; that value will be honored even if global persistence
+     *     is toggled true here.
      */
     public function __construct(
         CacheItemPoolInterface $cache,


### PR DESCRIPTION
zend-expressive-session 1.2.0 adds `SessionCookiePersistenceInterface`, which defines methods middleware developers can call in order to set the TTL for a session, and methods for persistence engines to call to determine if a per-session TTL was set.

This patch adapts `CacheSessionPersistence` to honor the new `getSessionLifetime()` method when determining whether or not to emit an `Expires` directive when creating and returning the `Set-Cookie` header.

When the engine does not have persistence enabled, the value of `getSessionLifetime()` will be used always to determine expiry. When persistence is enabled, if that method returns zero:

- If the session DOES NOT have the session lifetime key defined, the global persistence is used.
- If the session DOES have the session lifetime key defined, the session is expired.