### PR TITLE
Add options for cookie domain, secure, and httponly

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,33 +8,31 @@
     "packages": [
         {
             "name": "dflydev/fig-cookies",
-            "version": "v2.0.0",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
-                "reference": "a59857139b9e30978b5b802b3631b5eaf34e8c66"
+                "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/a59857139b9e30978b5b802b3631b5eaf34e8c66",
-                "reference": "a59857139b9e30978b5b802b3631b5eaf34e8c66",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/883233c159d00d39e940bd12cfe42c0d23420c1c",
+                "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c",
                 "shasum": ""
             },
             "require": {
-                "ext-pcre": "*",
-                "php": "^7.2",
-                "psr/http-message": "^1"
+                "php": ">=5.4",
+                "psr/http-message": "~1.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^4",
-                "phpstan/phpstan": "^0.10.1",
-                "phpunit/phpunit": "^7.2.6",
-                "squizlabs/php_codesniffer": "^3.3"
+                "codeclimate/php-test-reporter": "~0.1@dev",
+                "phpunit/phpunit": "~4.5",
+                "squizlabs/php_codesniffer": "~2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -58,7 +56,7 @@
                 "psr-7",
                 "psr7"
             ],
-            "time": "2018-07-11T06:54:37+00:00"
+            "time": "2016-03-28T09:10:18+00:00"
         },
         {
             "name": "psr/cache",
@@ -207,16 +205,16 @@
         },
         {
             "name": "psr/http-server-handler",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-server-handler.git",
-                "reference": "439d92054dc06097f2406ec074a2627839955a02"
+                "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/439d92054dc06097f2406ec074a2627839955a02",
-                "reference": "439d92054dc06097f2406ec074a2627839955a02",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
+                "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
                 "shasum": ""
             },
             "require": {
@@ -256,20 +254,20 @@
                 "response",
                 "server"
             ],
-            "time": "2018-01-22T17:04:15+00:00"
+            "time": "2018-10-30T16:46:14+00:00"
         },
         {
             "name": "psr/http-server-middleware",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-server-middleware.git",
-                "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5"
+                "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
-                "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/2296f45510945530b9dceb8bcedb5cb84d40c5f5",
+                "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +307,7 @@
                 "request",
                 "response"
             ],
-            "time": "2018-01-22T17:08:31+00:00"
+            "time": "2018-10-30T17:12:04+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
@@ -796,16 +794,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.8",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "848f78b3309780fef7ec8c4666b7ab4e6b09b22f"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/848f78b3309780fef7ec8c4666b7ab4e6b09b22f",
-                "reference": "848f78b3309780fef7ec8c4666b7ab4e6b09b22f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
@@ -816,7 +814,7 @@
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -829,7 +827,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -855,7 +853,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-04T03:41:23+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -999,16 +997,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
                 "shasum": ""
             },
             "require": {
@@ -1044,20 +1042,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01T13:16:43+00:00"
+            "time": "2018-10-30T05:52:18+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.4.0",
+            "version": "7.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3837fa1e07758057ae06e8ddec6d06ba183f126"
+                "reference": "7c89093bd00f7d5ddf0ab81dee04f801416b4944"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3837fa1e07758057ae06e8ddec6d06ba183f126",
-                "reference": "f3837fa1e07758057ae06e8ddec6d06ba183f126",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7c89093bd00f7d5ddf0ab81dee04f801416b4944",
+                "reference": "7c89093bd00f7d5ddf0ab81dee04f801416b4944",
                 "shasum": ""
             },
             "require": {
@@ -1078,7 +1076,7 @@
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
@@ -1102,7 +1100,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.4-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -1128,7 +1126,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-05T04:05:24+00:00"
+            "time": "2019-01-15T08:19:08+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1349,28 +1347,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "febd209a219cea7b56ad799b30ebbea34b71eb8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/febd209a219cea7b56ad799b30ebbea34b71eb8f",
+                "reference": "febd209a219cea7b56ad799b30ebbea34b71eb8f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1395,7 +1393,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2018-11-25T09:31:21+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1747,16 +1745,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -1821,7 +1819,65 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07T22:31:41+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "backendtea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1865,20 +1921,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -1911,7 +1968,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -1944,16 +2001,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "0bae78192e634774b5584f0210c1232da82cb1ff"
+                "reference": "c3c330192bc9cc51b7e9ce968ff721dc32ffa986"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/0bae78192e634774b5584f0210c1232da82cb1ff",
-                "reference": "0bae78192e634774b5584f0210c1232da82cb1ff",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/c3c330192bc9cc51b7e9ce968ff721dc32ffa986",
+                "reference": "c3c330192bc9cc51b7e9ce968ff721dc32ffa986",
                 "shasum": ""
             },
             "require": {
@@ -1976,8 +2033,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev",
-                    "dev-develop": "2.1.x-dev",
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
                     "dev-release-1.8": "1.8.x-dev"
                 }
             },
@@ -2006,7 +2063,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-09-27T19:49:04+00:00"
+            "time": "2019-01-05T20:13:32+00:00"
         }
     ],
     "aliases": [],

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -4,7 +4,10 @@ This package allows configuring the following items:
 
 - The PSR-6 `CacheItemPoolInterface` service to use.
 - The session cookie name.
+- The session cookie domain.
 - The session cookie path.
+- The session cookie secure option.
+- The session cookie httponly option.
 - The cache limiter (which controls how resources using sessions are cached by the browser).
 - When the session expires.
 - When the resource using a session was last modified.
@@ -92,8 +95,27 @@ return [
         // the syntax outlined in https://tools.ietf.org/html/rfc6265.html
         'cookie_name' => 'PHPSESSION',
 
+        // The (sub)domain that the cookie is available to. Setting this
+        // to a subdomain (such as 'www.example.com') will make the cookie
+        // available to that subdomain and all other sub-domains of it
+        // (i.e. w2.www.example.com). To make the cookie available to the
+        // whole domain (including all subdomains of it), simply set the
+        // value to the domain name ('example.com', in this case).
+        // Leave this null to use browser default (current hostname).
+        'cookie_domain' => null,
+
         // The path prefix of the cookie domain to which it applies.
         'cookie_path' => '/',
+
+        // Indicates that the cookie should only be transmitted over a
+        // secure HTTPS connection from the client. When set to TRUE, the
+        // cookie will only be set if a secure connection exists.
+        'cookie_secure' => false,
+
+        // When TRUE the cookie will be made accessible only through the
+        // HTTP protocol. This means that the cookie won't be accessible
+        // by scripting languages, such as JavaScript.
+        'cookie_http_only' => false,
 
         // Governs the various cache control headers emitted when
         // a session cookie is provided to the client. Value may be one
@@ -131,7 +153,7 @@ return [
 
 ## Using the service
 
-By default, this package define the service `Zend\Expressive\Session\Cache\CacheSessionPersistence`, 
+By default, this package define the service `Zend\Expressive\Session\Cache\CacheSessionPersistence`,
 assigning it to the factory `Zend\Expressive\Session\Cache\CacheSessionPersistenceFactory`.
 After you have installed the package, you will need to tell your application to
 use this service when using the `SessionMiddleware`.

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -29,7 +29,10 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
 public function __construct(
     \Psr\Cache\CacheItemPoolInterface $cache,
     string $cookieName,
+    string $cookieDomain = null,
     string $cookiePath = '/',
+    bool $cookieSecure = false,
+    bool $cookieHttpOnly = false,
     string $cacheLimiter = 'nocache',
     int $cacheExpire = 10800,
     ?int $lastModified = null,
@@ -48,7 +51,10 @@ $cachePool = new PredisCachePool('tcp://localhost:6379');
 $persistence = new CacheSessionPersistence(
     $cachePool,
     'MYSITE',
+    null
     '/',
+    false,
+    false,
     'public',
     60 * 60 * 24 * 30 // 30 days
 );

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -6,11 +6,12 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
 /**
  * Prepare session cache and default HTTP caching headers.
  *
- * The cache limiter setting is used to determine how to send HTTP
- * client-side caching headers. Those headers will be added
- * programmatically to the response along with the session set-cookie
- * header when the session data is persisted.
- *
+ * @param CacheItemPoolInterface $cache The cache pool instance
+ * @param string $cookieName The name of the cookie
+ * @param string $cacheLimiter The cache limiter setting is used to
+ *     determine how to send HTTP client-side caching headers. Those
+ *     headers will be added programmatically to the response along with
+ *     the session set-cookie header when the session data is persisted.
  * @param int $cacheExpire Number of seconds until the session cookie
  *     should expire; defaults to 180 minutes (180m * 60s/m = 10800s),
  *     which is the default of the PHP session.cache_expire setting. This
@@ -25,18 +26,28 @@ The following details the constructor of the `Zend\Expressive\Session\Cache\Cach
  *     runtime via the Session instance, using its persistSessionFor()
  *     method; that value will be honored even if global persistence
  *     is toggled true here.
+ * @param string|null $cookieDomain The domain for the cookie. If not set,
+ *     the current domain is used.
+ * @param bool $cookieSecure Whether or not the cookie should be required
+ *     to be set over an encrypted connection
+ * @param bool $cookieHttpOnly Whether or not the cookie may be accessed
+ *     by client-side apis (e.g., Javascript). An http-only cookie cannot
+ *     be accessed by client-side apis.
+ *
+ * @todo reorder these arguments so they make more sense and are in an
+ *     order of importance
  */
 public function __construct(
-    \Psr\Cache\CacheItemPoolInterface $cache,
+    CacheItemPoolInterface $cache,
     string $cookieName,
-    string $cookieDomain = null,
     string $cookiePath = '/',
-    bool $cookieSecure = false,
-    bool $cookieHttpOnly = false,
     string $cacheLimiter = 'nocache',
     int $cacheExpire = 10800,
     ?int $lastModified = null,
-    bool $persistent = false
+    bool $persistent = false,
+    string $cookieDomain = null,
+    bool $cookieSecure = false,
+    bool $cookieHttpOnly = false
 ) {
 ```
 
@@ -50,11 +61,8 @@ use Zend\Expressive\Session\SessionMiddleware;
 $cachePool = new PredisCachePool('tcp://localhost:6379');
 $persistence = new CacheSessionPersistence(
     $cachePool,
-    'MYSITE',
-    null
+    'MYSITE'
     '/',
-    false,
-    false,
     'public',
     60 * 60 * 24 * 30 // 30 days
 );

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -72,8 +72,17 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     /** @var string */
     private $cookieName;
 
+    /** @var string|null */
+    private $cookieDomain;
+
     /** @var string */
     private $cookiePath;
+
+    /** @var bool */
+    private $cookieSecure;
+
+    /** @var bool */
+    private $cookieHttpOnly;
 
     /** @var false|string */
     private $lastModified;
@@ -107,7 +116,10 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     public function __construct(
         CacheItemPoolInterface $cache,
         string $cookieName,
+        string $cookieDomain = null,
         string $cookiePath = '/',
+        bool $cookieSecure = false,
+        bool $cookieHttpOnly = false,
         string $cacheLimiter = 'nocache',
         int $cacheExpire = 10800,
         ?int $lastModified = null,
@@ -120,7 +132,13 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         }
         $this->cookieName = $cookieName;
 
+        $this->cookieDomain = $cookieDomain;
+
         $this->cookiePath = $cookiePath;
+
+        $this->cookieSecure = $cookieSecure;
+
+        $this->cookieHttpOnly = $cookieHttpOnly;
 
         $this->cacheLimiter = in_array($cacheLimiter, self::SUPPORTED_CACHE_LIMITERS, true)
             ? $cacheLimiter
@@ -165,7 +183,10 @@ class CacheSessionPersistence implements SessionPersistenceInterface
 
         $sessionCookie = SetCookie::create($this->cookieName)
             ->withValue($id)
-            ->withPath($this->cookiePath);
+            ->withDomain($this->cookieDomain)
+            ->withPath($this->cookiePath)
+            ->withSecure($this->cookieSecure)
+            ->withHttpOnly($this->cookieHttpOnly);
 
         $persistenceDuration = $this->getPersistenceDuration($session);
         if ($persistenceDuration) {

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -121,7 +121,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      *     by client-side apis (e.g., Javascript). An http-only cookie cannot
      *     be accessed by client-side apis.
      *
-     * @todo reorder the constructor arguments 
+     * @todo reorder the constructor arguments
      */
     public function __construct(
         CacheItemPoolInterface $cache,

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -93,11 +93,12 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     /**
      * Prepare session cache and default HTTP caching headers.
      *
-     * The cache limiter setting is used to determine how to send HTTP
-     * client-side caching headers. Those headers will be added
-     * programmatically to the response along with the session set-cookie
-     * header when the session data is persisted.
-     *
+     * @param CacheItemPoolInterface $cache The cache pool instance
+     * @param string $cookieName The name of the cookie
+     * @param string $cacheLimiter The cache limiter setting is used to
+     *     determine how to send HTTP client-side caching headers. Those
+     *     headers will be added programmatically to the response along with
+     *     the session set-cookie header when the session data is persisted.
      * @param int $cacheExpire Number of seconds until the session cookie
      *     should expire; defaults to 180 minutes (180m * 60s/m = 10800s),
      *     which is the default of the PHP session.cache_expire setting. This
@@ -112,18 +113,27 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      *     runtime via the Session instance, using its persistSessionFor()
      *     method; that value will be honored even if global persistence
      *     is toggled true here.
+     * @param string|null $cookieDomain The domain for the cookie. If not set,
+     *     the current domain is used.
+     * @param bool $cookieSecure Whether or not the cookie should be required
+     *     to be set over an encrypted connection
+     * @param bool $cookieHttpOnly Whether or not the cookie may be accessed
+     *     by client-side apis (e.g., Javascript). An http-only cookie cannot
+     *     be accessed by client-side apis.
+     *
+     * @todo reorder the constructor arguments 
      */
     public function __construct(
         CacheItemPoolInterface $cache,
         string $cookieName,
-        string $cookieDomain = null,
         string $cookiePath = '/',
-        bool $cookieSecure = false,
-        bool $cookieHttpOnly = false,
         string $cacheLimiter = 'nocache',
         int $cacheExpire = 10800,
         ?int $lastModified = null,
-        bool $persistent = false
+        bool $persistent = false,
+        string $cookieDomain = null,
+        bool $cookieSecure = false,
+        bool $cookieHttpOnly = false
     ) {
         $this->cache = $cache;
 

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -25,17 +25,23 @@ class CacheSessionPersistenceFactory
             throw Exception\MissingDependencyException::forService($cacheService);
         }
 
-        $cookieName   = $config['cookie_name'] ?? 'PHPSESSION';
-        $cookiePath   = $config['cookie_path'] ?? '/';
-        $cacheLimiter = $config['cache_limiter'] ?? 'nocache';
-        $cacheExpire  = $config['cache_expire'] ?? 10800;
-        $lastModified = $config['last_modified'] ?? null;
-        $persistent   = $config['persistent'] ?? false;
+        $cookieName     = $config['cookie_name'] ?? 'PHPSESSION';
+        $cookieDomain   = $config['cookie_domain'] ?? null;
+        $cookiePath     = $config['cookie_path'] ?? '/';
+        $cookieSecure   = $config['cookie_secure'] ?? false;
+        $cookieHttpOnly = $config['cookie_http_only'] ?? false;
+        $cacheLimiter   = $config['cache_limiter'] ?? 'nocache';
+        $cacheExpire    = $config['cache_expire'] ?? 10800;
+        $lastModified   = $config['last_modified'] ?? null;
+        $persistent     = $config['persistent'] ?? false;
 
         return new CacheSessionPersistence(
             $container->get($cacheService),
             $cookieName,
+            $cookieDomain,
             $cookiePath,
+            $cookieSecure,
+            $cookieHttpOnly,
             $cacheLimiter,
             $cacheExpire,
             $lastModified,

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -38,14 +38,14 @@ class CacheSessionPersistenceFactory
         return new CacheSessionPersistence(
             $container->get($cacheService),
             $cookieName,
-            $cookieDomain,
             $cookiePath,
-            $cookieSecure,
-            $cookieHttpOnly,
             $cacheLimiter,
             $cacheExpire,
             $lastModified,
-            $persistent
+            $persistent,
+            $cookieDomain,
+            $cookieSecure,
+            $cookieHttpOnly
         );
     }
 }

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -55,6 +55,9 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         // These we did not
         $this->assertAttributeSame('PHPSESSION', 'cookieName', $persistence);
         $this->assertAttributeSame('/', 'cookiePath', $persistence);
+        $this->assertAttributeSame(null, 'cookieDomain', $persistence);
+        $this->assertAttributeSame(false, 'cookieSecure', $persistence);
+        $this->assertAttributeSame(false, 'cookieHttpOnly', $persistence);
         $this->assertAttributeSame('nocache', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
@@ -70,12 +73,15 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'zend-expressive-session-cache' => [
-                'cookie_name'   => 'TESTING',
-                'cookie_path'   => '/api',
-                'cache_limiter' => 'public',
-                'cache_expire'  => 300,
-                'last_modified' => $lastModified,
-                'persistent'    => true,
+                'cookie_name'      => 'TESTING',
+                'cookie_domain'    => 'example.com',
+                'cookie_path'      => '/api',
+                'cookie_secure'    => true,
+                'cookie_http_only' => true,
+                'cache_limiter'    => 'public',
+                'cache_expire'     => 300,
+                'last_modified'    => $lastModified,
+                'persistent'       => true,
             ],
         ]);
         $this->container->has(CacheItemPoolInterface::class)->willReturn(true);
@@ -87,6 +93,9 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertAttributeSame($cachePool, 'cache', $persistence);
         $this->assertAttributeSame('TESTING', 'cookieName', $persistence);
         $this->assertAttributeSame('/api', 'cookiePath', $persistence);
+        $this->assertAttributeSame('example.com', 'cookieDomain', $persistence);
+        $this->assertAttributeSame(true, 'cookieSecure', $persistence);
+        $this->assertAttributeSame(true, 'cookieHttpOnly', $persistence);
         $this->assertAttributeSame('public', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(300, 'cacheExpire', $persistence);
         $this->assertAttributeSame(

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -270,7 +270,10 @@ class CacheSessionPersistenceTest extends TestCase
         $this->assertAttributeSame('test', 'cookieName', $persistence);
 
         // These we did not
+        $this->assertAttributeSame(null, 'cookieDomain', $persistence);
         $this->assertAttributeSame('/', 'cookiePath', $persistence);
+        $this->assertAttributeSame(false, 'cookieSecure', $persistence);
+        $this->assertAttributeSame(false, 'cookieHttpOnly', $persistence);
         $this->assertAttributeSame('nocache', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
@@ -296,7 +299,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            'example.com',
             '/api',
+            true,
+            true,
             $cacheLimiter,
             100,
             $lastModified
@@ -305,6 +311,9 @@ class CacheSessionPersistenceTest extends TestCase
         $this->assertAttributeSame($this->cachePool->reveal(), 'cache', $persistence);
         $this->assertAttributeSame('test', 'cookieName', $persistence);
         $this->assertAttributeSame('/api', 'cookiePath', $persistence);
+        $this->assertAttributeSame('example.com', 'cookieDomain', $persistence);
+        $this->assertAttributeSame(true, 'cookieSecure', $persistence);
+        $this->assertAttributeSame(true, 'cookieHttpOnly', $persistence);
         $this->assertAttributeSame($cacheLimiter, 'cacheLimiter', $persistence);
         $this->assertAttributeSame(100, 'cacheExpire', $persistence);
         $this->assertAttributeSame(
@@ -319,13 +328,19 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            'example.com',
             '/api',
+            true,
+            true,
             'not-valid'
         );
 
         $this->assertAttributeSame($this->cachePool->reveal(), 'cache', $persistence);
         $this->assertAttributeSame('test', 'cookieName', $persistence);
+        $this->assertAttributeSame('example.com', 'cookieDomain', $persistence);
         $this->assertAttributeSame('/api', 'cookiePath', $persistence);
+        $this->assertAttributeSame(true, 'cookieSecure', $persistence);
+        $this->assertAttributeSame(true, 'cookieHttpOnly', $persistence);
         $this->assertAttributeSame('nocache', 'cacheLimiter', $persistence);
     }
 
@@ -412,7 +427,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             $cacheLimiter,
             10800,
             time()
@@ -446,7 +464,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             $cacheLimiter,
             10800,
             time()
@@ -476,7 +497,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             $cacheLimiter,
             10800,
             time()
@@ -517,7 +541,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             $cacheLimiter,
             10800,
             time()
@@ -558,7 +585,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             $cacheLimiter,
             10800,
             time()
@@ -599,7 +629,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             $cacheLimiter,
             10800,
             time()
@@ -677,7 +710,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             'nocache',
             600, // expiry
             time(),
@@ -744,7 +780,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             'nocache',
             600, // expiry
             time(),
@@ -829,7 +868,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             'nocache',
             600, // expiry
             time(),
@@ -872,7 +914,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             'nocache',
             600, // expiry
             time(),
@@ -919,7 +964,10 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
+            null,
             '/',
+            false,
+            false,
             'nocache',
             600, // expiry
             time(),

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -299,13 +299,14 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            'example.com',
             '/api',
-            true,
-            true,
             $cacheLimiter,
             100,
-            $lastModified
+            $lastModified,
+            false,
+            'example.com',
+            true,
+            true
         );
 
         $this->assertAttributeSame($this->cachePool->reveal(), 'cache', $persistence);
@@ -328,11 +329,14 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            'example.com',
             '/api',
+            'not-valid',
+            100,
+            null,
+            false,
+            'example.com',
             true,
-            true,
-            'not-valid'
+            true
         );
 
         $this->assertAttributeSame($this->cachePool->reveal(), 'cache', $persistence);
@@ -427,10 +431,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             $cacheLimiter,
             10800,
             time()
@@ -464,10 +465,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             $cacheLimiter,
             10800,
             time()
@@ -497,10 +495,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             $cacheLimiter,
             10800,
             time()
@@ -541,10 +536,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             $cacheLimiter,
             10800,
             time()
@@ -585,10 +577,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             $cacheLimiter,
             10800,
             time()
@@ -629,10 +618,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             $cacheLimiter,
             10800,
             time()
@@ -710,10 +696,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             'nocache',
             600, // expiry
             time(),
@@ -780,10 +763,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             'nocache',
             600, // expiry
             time(),
@@ -868,10 +848,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             'nocache',
             600, // expiry
             time(),
@@ -914,10 +891,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             'nocache',
             600, // expiry
             time(),
@@ -964,10 +938,7 @@ class CacheSessionPersistenceTest extends TestCase
         $persistence = new CacheSessionPersistence(
             $this->cachePool->reveal(),
             'test',
-            null,
             '/',
-            false,
-            false,
             'nocache',
             600, // expiry
             time(),


### PR DESCRIPTION
This patch provides the ability to set additional options for for the generated session `Set-Cookie` header, including:

- domain
- secure
- httponly

Changes include tests and documentation updates.